### PR TITLE
show deprecation for showFullPath

### DIFF
--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -44,7 +44,7 @@ export class FileController {
     };
 
     const showFullPath = config.get('showFullPath') as ( boolean | undefined);
-    if (showFullPath) {
+    if (showFullPath !== undefined) {
       window.showInformationMessage('You are using a deprecated option "showFullPath". Switch instead to "showFullPathRelativeTo"');
       this.settings.showPathRelativeTo = 'root';
     }


### PR DESCRIPTION
If the setting is `false` the deprecation warning would not show.