### PR TITLE
Remove "newFile.showFullPath"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,6 @@
                     "default": "root",
                     "description": "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root."
                 },
-                "newFile.showFullPath": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "[DEPRECATED] Use newFile.showPathRelativeTo: none instead."
-                },
                 "newFile.relativeTo": {
                     "type": "string",
                     "enum": [


### PR DESCRIPTION
This PR removes the `"newFile.showFullPath"` configuration option so that users don't get constant deprecation messages when creating new files, despite not having `"newFile.showFullpath"` set in their user preferences.

Currently, the code is checking that this property exists in the configuration and shows a deprecation message if it does. The problem is, by setting it here, it will exist anyway, regardless of what the user does.