### PR TITLE
Add Workspace support introduced in Code 1.18. Fixes #29

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
   },
 
   "prettier.trailingComma": "es5",
-  "prettier.singleQuote": true
+  "prettier.singleQuote": true,
+  "prettier.jsonEnable": []
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-new-file",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3490,15 +3490,6 @@
       "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3507,6 +3498,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
             "none"
           ],
           "default": "root",
-          "description": "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root.",
+          "description": "Lets you configure what the path should be shown relative to. 'root' is the equivalent of showing the whole URL based on the configured root.",
           "scope": "resource"
         },
         "newFile.relativeTo": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "engines": {
     "vscode": "^1.18.0"
   },
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "bugs": {
     "url": "https://github.com/dkundel/vscode-new-file/issues"
   },
@@ -33,32 +35,36 @@
       "properties": {
         "newFile.showPathRelativeTo": {
           "type": "string",
-          "enum": ["root", "project", "none"],
+          "enum": [
+            "root",
+            "project",
+            "none"
+          ],
           "default": "root",
-          "description":
-            "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root.",
+          "description": "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root.",
           "scope": "resource"
         },
         "newFile.relativeTo": {
           "type": "string",
-          "enum": ["file", "project", "root"],
+          "enum": [
+            "file",
+            "project",
+            "root"
+          ],
           "default": "file",
-          "description":
-            "Whether the entered path should be treated relative to the existing 'project', the currently selected 'file' or specified 'root'. If set to 'root' you need to set the 'rootDirectory' setting.",
+          "description": "Whether the entered path should be treated relative to the existing 'project', the currently selected 'file' or specified 'root'. If set to 'root' you need to set the 'rootDirectory' setting.",
           "scope": "resource"
         },
         "newFile.rootDirectory": {
           "type": "string",
           "default": "~",
-          "description":
-            "Only used when 'relativeTo' is set to 'root'. Used as the root for creating new files.",
+          "description": "Only used when 'relativeTo' is set to 'root'. Used as the root for creating new files.",
           "scope": "resource"
         },
         "newFile.defaultFileExtension": {
           "type": "string",
           "default": ".ts",
-          "description":
-            "Default file extension to be used when no file is open.",
+          "description": "Default file extension to be used when no file is open.",
           "scope": "resource"
         },
         "newFile.defaultBaseFileName": {
@@ -70,22 +76,19 @@
         "newFile.expandBraces": {
           "type": "boolean",
           "default": false,
-          "description":
-            "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js",
+          "description": "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js",
           "scope": "resource"
         },
         "newFile.fileTemplates": {
           "type": "object",
           "default": {},
-          "description":
-            "Object of mappings from file extension to path for template file. The paths can be relative to the 'rootDirectory' or absolute paths.",
+          "description": "Object of mappings from file extension to path for template file. The paths can be relative to the 'rootDirectory' or absolute paths.",
           "scope": "resource"
         },
         "newFile.useFileTemplates": {
           "type": "boolean",
           "default": true,
-          "description":
-            "If enabled it will look up template files in newFile.fileTemplates for file creation.",
+          "description": "If enabled it will look up template files in newFile.fileTemplates for file creation.",
           "scope": "resource"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,150 +1,155 @@
 {
-    "name": "vscode-new-file",
-    "displayName": "Advanced New File",
-    "description": "An easier way of creating a new file inside a project.",
-    "version": "3.2.2",
-    "icon": "images/logo-300x.png",
-    "galleryBanner": {
-        "color": "#eeeeee",
-        "theme": "light"
-    },
-    "license": "MIT",
-    "publisher": "dkundel",
-    "engines": {
-        "vscode": "^1.12.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "bugs": {
-        "url": "https://github.com/dkundel/vscode-new-file/issues"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/dkundel/vscode-new-file.git"
-    },
-    "activationEvents": [
-        "onCommand:newFile.createFromExplorer",
-        "onCommand:newFile.createNewFile"
-    ],
-    "main": "./out/src/extension",
-    "contributes": {
-        "configuration": {
-            "title": "New File Extension Configuration",
-            "type": "object",
-            "properties": {
-                "newFile.showPathRelativeTo": {
-                    "type": "string",
-                    "enum": [
-                        "root",
-                        "project",
-                        "none"
-                    ],
-                    "default": "root",
-                    "description": "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root."
-                },
-                "newFile.relativeTo": {
-                    "type": "string",
-                    "enum": [
-                        "file",
-                        "project",
-                        "root"
-                    ],
-                    "default": "file",
-                    "description": "Whether the entered path should be treated relative to the existing 'project', the currently selected 'file' or specified 'root'. If set to 'root' you need to set the 'rootDirectory' setting."
-                },
-                "newFile.rootDirectory": {
-                    "type": "string",
-                    "default": "~",
-                    "description": "Only used when 'relativeTo' is set to 'root'. Used as the root for creating new files."
-                },
-                "newFile.defaultFileExtension": {
-                    "type": "string",
-                    "default": ".ts",
-                    "description": "Default file extension to be used when no file is open."
-                },
-                "newFile.defaultBaseFileName": {
-                    "type": "string",
-                    "default": "newFile",
-                    "description": "Default base file name."
-                },
-                "newFile.expandBraces": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js"
-                },
-                "newFile.fileTemplates": {
-                    "type": "object",
-                    "default": {},
-                    "description": "Object of mappings from file extension to path for template file. The paths can be relative to the 'rootDirectory' or absolute paths."
-                },
-                "newFile.useFileTemplates": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "If enabled it will look up template files in newFile.fileTemplates for file creation."
-                }
-            }
+  "name": "vscode-new-file",
+  "displayName": "Advanced New File",
+  "description": "An easier way of creating a new file inside a project.",
+  "version": "3.2.2",
+  "icon": "images/logo-300x.png",
+  "galleryBanner": {
+    "color": "#eeeeee",
+    "theme": "light"
+  },
+  "license": "MIT",
+  "publisher": "dkundel",
+  "engines": {
+    "vscode": "^1.18.0"
+  },
+  "categories": ["Other"],
+  "bugs": {
+    "url": "https://github.com/dkundel/vscode-new-file/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dkundel/vscode-new-file.git"
+  },
+  "activationEvents": [
+    "onCommand:newFile.createFromExplorer",
+    "onCommand:newFile.createNewFile"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "configuration": {
+      "title": "New File Extension Configuration",
+      "type": "object",
+      "properties": {
+        "newFile.showPathRelativeTo": {
+          "type": "string",
+          "enum": ["root", "project", "none"],
+          "default": "root",
+          "description":
+            "Let's you configure relative to what the path should be shown. 'root' is the equivalent of showing the whole URL base don the configured root.",
+          "scope": "resource"
         },
-        "commands": [
-            {
-                "command": "newFile.createNewFile",
-                "title": "Files: Advanced New File"
-            },
-            {
-                "command": "newFile.createFromExplorer",
-                "title": "Advanced New File"
-            }
-        ],
-        "keybindings": [
-            {
-                "command": "newFile.createNewFile",
-                "key": "alt+ctrl+n",
-                "mac": "alt+cmd+n"
-            }
-        ],
-        "menus": {
-            "explorer/context": [
-                {
-                    "command": "newFile.createFromExplorer"
-                }
-            ]
+        "newFile.relativeTo": {
+          "type": "string",
+          "enum": ["file", "project", "root"],
+          "default": "file",
+          "description":
+            "Whether the entered path should be treated relative to the existing 'project', the currently selected 'file' or specified 'root'. If set to 'root' you need to set the 'rootDirectory' setting.",
+          "scope": "resource"
+        },
+        "newFile.rootDirectory": {
+          "type": "string",
+          "default": "~",
+          "description":
+            "Only used when 'relativeTo' is set to 'root'. Used as the root for creating new files.",
+          "scope": "resource"
+        },
+        "newFile.defaultFileExtension": {
+          "type": "string",
+          "default": ".ts",
+          "description":
+            "Default file extension to be used when no file is open.",
+          "scope": "resource"
+        },
+        "newFile.defaultBaseFileName": {
+          "type": "string",
+          "default": "newFile",
+          "description": "Default base file name.",
+          "scope": "resource"
+        },
+        "newFile.expandBraces": {
+          "type": "boolean",
+          "default": false,
+          "description":
+            "Whether braces should be expanded to multiple paths (such as {test1,test2}.js creating two files, test1.js and test2.js",
+          "scope": "resource"
+        },
+        "newFile.fileTemplates": {
+          "type": "object",
+          "default": {},
+          "description":
+            "Object of mappings from file extension to path for template file. The paths can be relative to the 'rootDirectory' or absolute paths.",
+          "scope": "resource"
+        },
+        "newFile.useFileTemplates": {
+          "type": "boolean",
+          "default": true,
+          "description":
+            "If enabled it will look up template files in newFile.fileTemplates for file creation.",
+          "scope": "resource"
         }
+      }
     },
-    "scripts": {
-        "vscode:prepublish": "tsc -p ./",
-        "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "pretest": "npm run lint",
-        "test": "node ./node_modules/vscode/bin/test",
-        "lint": "tslint src/**/*.ts",
-        "lint:fix": "npm run lint -- --fix",
-        "contrib:add": "all-contributors add",
-        "contrib:generate": "all-contributors generate"
-    },
-    "devDependencies": {
-        "@types/expect.js": "^0.3.29",
-        "@types/mocha": "^2.2.41",
-        "@types/mockery": "^1.4.29",
-        "@types/node": "^7.0.18",
-        "@types/rimraf": "^0.0.28",
-        "all-contributors-cli": "^4.5.1",
-        "mocha": "^3.4.1",
-        "mockery": "^1.4.0",
-        "prettier": "^1.7.4",
-        "rimraf": "^2.4.4",
-        "tslint": "^5.8.0",
-        "tslint-config-prettier": "^1.6.0",
-        "tslint-plugin-prettier": "^1.3.0",
-        "typescript": "^2.3.2",
-        "vscode": "^1.1.0"
-    },
-    "dependencies": {
-        "@types/debug": "^0.0.29",
-        "@types/mkdirp": "^0.3.29",
-        "@types/q": "^1.0.0",
-        "braces": "^2.2.2",
-        "debug": "^2.6.7",
-        "mkdirp": "^0.5.1",
-        "q": "^1.4.1"
+    "commands": [
+      {
+        "command": "newFile.createNewFile",
+        "title": "Files: Advanced New File"
+      },
+      {
+        "command": "newFile.createFromExplorer",
+        "title": "Advanced New File"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "newFile.createNewFile",
+        "key": "alt+ctrl+n",
+        "mac": "alt+cmd+n"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "newFile.createFromExplorer"
+        }
+      ]
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "pretest": "npm run lint",
+    "test": "node ./node_modules/vscode/bin/test",
+    "lint": "tslint src/**/*.ts",
+    "lint:fix": "npm run lint -- --fix",
+    "contrib:add": "all-contributors add",
+    "contrib:generate": "all-contributors generate"
+  },
+  "devDependencies": {
+    "@types/expect.js": "^0.3.29",
+    "@types/mocha": "^2.2.41",
+    "@types/mockery": "^1.4.29",
+    "@types/node": "^7.0.18",
+    "@types/rimraf": "^0.0.28",
+    "all-contributors-cli": "^4.5.1",
+    "mocha": "^3.4.1",
+    "mockery": "^1.4.0",
+    "prettier": "^1.7.4",
+    "rimraf": "^2.4.4",
+    "tslint": "^5.8.0",
+    "tslint-config-prettier": "^1.6.0",
+    "tslint-plugin-prettier": "^1.3.0",
+    "typescript": "^2.3.2",
+    "vscode": "^1.1.0"
+  },
+  "dependencies": {
+    "@types/debug": "^0.0.29",
+    "@types/mkdirp": "^0.3.29",
+    "@types/q": "^1.0.0",
+    "braces": "^2.2.2",
+    "debug": "^2.6.7",
+    "mkdirp": "^0.5.1",
+    "q": "^1.4.1"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,10 +60,10 @@ export function activate(context: ExtensionContext) {
         return;
       }
 
-      const File = new FileController().readSettings();
+      const File = new FileController().readSettings(file);
 
       try {
-        const root = await File.getRootFromExplorerPath(file.path);
+        const root = await File.getRootFromExplorerPath(file.fsPath);
         const defaultFileName = await File.getDefaultFileValue(root);
         const userFilePath = await File.showFileNameDialog(
           defaultFileName,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,8 @@ export function activate(context: ExtensionContext) {
       const File = new FileController().readSettings();
 
       try {
-        const root = File.determineRoot();
-        const defaultFileName = File.getDefaultFileValue(root);
+        const root = await File.determineRoot();
+        const defaultFileName = await File.getDefaultFileValue(root);
         const userFilePath = await File.showFileNameDialog(defaultFileName);
         const createdFiles = await File.createFiles(userFilePath);
         await File.openFilesInEditor(createdFiles);
@@ -38,8 +38,8 @@ export function activate(context: ExtensionContext) {
       const File = new FileController().readSettings();
 
       try {
-        const root = File.determineRoot();
-        const defaultFileName = File.getDefaultFileValue(root);
+        const root = await File.determineRoot();
+        const defaultFileName = await File.getDefaultFileValue(root);
         const userFilePath = await File.showFileNameDialog(defaultFileName);
         const createdFiles = await File.createFiles(userFilePath);
         await File.openFilesInEditor(createdFiles);
@@ -64,7 +64,7 @@ export function activate(context: ExtensionContext) {
 
       try {
         const root = await File.getRootFromExplorerPath(file.path);
-        const defaultFileName = File.getDefaultFileValue(root);
+        const defaultFileName = await File.getDefaultFileValue(root);
         const userFilePath = await File.showFileNameDialog(
           defaultFileName,
           true

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,30 +29,6 @@ export function activate(context: ExtensionContext) {
 
   context.subscriptions.push(disposable);
 
-  const disposableDeprecated = commands.registerCommand(
-    'extension.createNewFile',
-    async () => {
-      window.showWarningMessage(
-        'You are using a deprecated event. Please switch your keyboard shortcut to use "newFile.createNewFile"'
-      );
-      const File = new FileController().readSettings();
-
-      try {
-        const root = await File.determineRoot();
-        const defaultFileName = await File.getDefaultFileValue(root);
-        const userFilePath = await File.showFileNameDialog(defaultFileName);
-        const createdFiles = await File.createFiles(userFilePath);
-        await File.openFilesInEditor(createdFiles);
-      } catch (err) {
-        if (err && err.message) {
-          window.showErrorMessage(err.message);
-        }
-      }
-    }
-  );
-
-  context.subscriptions.push(disposableDeprecated);
-
   const disposableExplorerEntry = commands.registerCommand(
     'newFile.createFromExplorer',
     async file => {

--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -45,8 +45,8 @@ export class FileController {
   private currentUri?: Uri;
   private workspaceRoot?: string;
 
-  public readSettings(): FileController {
-    this.currentUri = this.getUriOfCurrentFile();
+  public readSettings(currentUri?: Uri): FileController {
+    this.currentUri = currentUri || this.getUriOfCurrentFile();
     const config = workspace.getConfiguration('newFile', this.currentUri);
 
     this.settings = {
@@ -285,7 +285,11 @@ export class FileController {
       return workspace.getWorkspaceFolder(currentUri);
     }
 
-    return window.showWorkspaceFolderPick();
+    const selectedWorkspaceFolder = await window.showWorkspaceFolderPick();
+    if (selectedWorkspaceFolder !== undefined) {
+      this.readSettings(selectedWorkspaceFolder.uri);
+    }
+    return selectedWorkspaceFolder;
   }
 
   private getRootPathFromWorkspace(

--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -4,6 +4,7 @@ import {
   QuickPickItem,
   QuickPickOptions,
   TextEditor,
+  Uri,
   window,
   workspace,
 } from 'vscode';
@@ -42,7 +43,8 @@ export class FileController {
   private rootPath: string;
 
   public readSettings(): FileController {
-    const config = workspace.getConfiguration('newFile');
+    const currentUri = this.getUriOfCurrentFile();
+    const config = workspace.getConfiguration('newFile', currentUri);
 
     this.settings = {
       defaultBaseFileName: config.get('defaultBaseFileName', 'newFile'),
@@ -255,6 +257,11 @@ export class FileController {
     }
 
     return path.resolve(root, filePath);
+  }
+
+  private getUriOfCurrentFile(): Uri | undefined {
+    const editor = window.activeTextEditor;
+    return editor ? editor.document.uri : undefined;
   }
 
   private homedir(): string {

--- a/src/file-controller.ts
+++ b/src/file-controller.ts
@@ -7,6 +7,7 @@ import {
   Uri,
   window,
   workspace,
+  WorkspaceFolder,
 } from 'vscode';
 
 import * as braces from 'braces';
@@ -41,10 +42,12 @@ export class FileController {
   private settings: NewFileSettings;
 
   private rootPath: string;
+  private currentUri?: Uri;
+  private workspaceRoot?: string;
 
   public readSettings(): FileController {
-    const currentUri = this.getUriOfCurrentFile();
-    const config = workspace.getConfiguration('newFile', currentUri);
+    this.currentUri = this.getUriOfCurrentFile();
+    const config = workspace.getConfiguration('newFile', this.currentUri);
 
     this.settings = {
       defaultBaseFileName: config.get('defaultBaseFileName', 'newFile'),
@@ -80,16 +83,18 @@ export class FileController {
     return dir;
   }
 
-  public determineRoot(): string {
+  public async determineRoot(): Promise<string> {
     let root: string;
 
     if (this.settings.relativeTo === 'project') {
-      root = workspace.rootPath;
+      this.workspaceRoot = await this.determineWorkspaceRoot();
+      root = this.workspaceRoot;
     } else if (this.settings.relativeTo === 'file') {
       if (window.activeTextEditor) {
         root = path.dirname(window.activeTextEditor.document.fileName);
-      } else if (workspace.rootPath) {
-        root = workspace.rootPath;
+      } else {
+        this.workspaceRoot = await this.determineWorkspaceRoot();
+        root = this.workspaceRoot;
       }
     }
 
@@ -106,7 +111,7 @@ export class FileController {
     return root;
   }
 
-  public getDefaultFileValue(root: string): string {
+  public async getDefaultFileValue(root: string): Promise<string> {
     const newFileName = this.settings.defaultBaseFileName;
     const defaultExtension = this.settings.defaultFileExtension;
 
@@ -118,7 +123,10 @@ export class FileController {
     if (this.settings.showPathRelativeTo !== 'none') {
       const fullPath = path.join(root, `${newFileName}${ext}`);
       if (this.settings.showPathRelativeTo === 'project') {
-        return fullPath.replace(workspace.rootPath + path.sep, '');
+        if (!this.workspaceRoot) {
+          this.workspaceRoot = await this.determineWorkspaceRoot();
+        }
+        return fullPath.replace(this.workspaceRoot + path.sep, '');
       }
       return fullPath;
     } else {
@@ -162,8 +170,11 @@ export class FileController {
       } else {
         if (this.settings.showPathRelativeTo !== 'none') {
           if (this.settings.showPathRelativeTo === 'project') {
+            if (!this.workspaceRoot) {
+              this.workspaceRoot = await this.determineWorkspaceRoot();
+            }
             selectedFilePath = path.resolve(
-              workspace.rootPath,
+              this.workspaceRoot,
               selectedFilePath
             );
           }
@@ -235,14 +246,17 @@ export class FileController {
     });
   }
 
-  private normalizeDotPath(filePath: string): string {
+  private async normalizeDotPath(filePath: string): Promise<string> {
     const currentFileName: string = window.activeTextEditor
       ? window.activeTextEditor.document.fileName
       : '';
+    if (!this.workspaceRoot) {
+      this.workspaceRoot = await this.determineWorkspaceRoot();
+    }
     const directory =
       currentFileName.length > 0
         ? path.dirname(currentFileName)
-        : workspace.rootPath;
+        : this.workspaceRoot;
 
     return path.resolve(directory, filePath);
   }
@@ -262,6 +276,43 @@ export class FileController {
   private getUriOfCurrentFile(): Uri | undefined {
     const editor = window.activeTextEditor;
     return editor ? editor.document.uri : undefined;
+  }
+
+  private async determineWorkspaceFolder(
+    currentUri: Uri
+  ): Promise<WorkspaceFolder | undefined> {
+    if (currentUri) {
+      return workspace.getWorkspaceFolder(currentUri);
+    }
+
+    return window.showWorkspaceFolderPick();
+  }
+
+  private getRootPathFromWorkspace(
+    currentWorkspace?: WorkspaceFolder
+  ): string | undefined | null {
+    if (typeof currentWorkspace === 'undefined') {
+      return undefined;
+    }
+
+    if (currentWorkspace.uri.scheme !== 'file') {
+      return null;
+    }
+
+    return currentWorkspace.uri.fsPath;
+  }
+
+  private async determineWorkspaceRoot(): Promise<string | undefined> {
+    const currentWorkspace = await this.determineWorkspaceFolder(
+      this.currentUri
+    );
+    const workspaceRoot = this.getRootPathFromWorkspace(currentWorkspace);
+    if (workspaceRoot === null) {
+      throw new Error(
+        'This extension currently only support file system workspaces.'
+      );
+    }
+    return workspaceRoot;
   }
 
   private homedir(): string {


### PR DESCRIPTION
This is moving from `workspace.rootPath` to supporting multiple folders in a workspace. This was introduced in VS Code 1.18. More information in the issue #29.